### PR TITLE
Endpoints 3 - 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ group :development, :test do
   gem "pry"
   gem "rspec-rails"
   gem "shoulda-matchers"
+  gem 'factory_bot_rails'
+  gem "faker"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,13 @@ GEM
     docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
+    factory_bot (6.5.1)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.4.4)
+      factory_bot (~> 6.5)
+      railties (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.10.1)
       faraday-net_http (>= 2.0, < 3.2)
       logger
@@ -255,6 +262,8 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
+  factory_bot_rails
+  faker
   faraday
   jsonapi-serializer
   pg (~> 1.1)

--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::InvitationsController < ApplicationController
+  def create
+    party = Invitation.add_user_to_party(params[:viewing_party_id], params[:invitees_user_id])
+    render json: ViewingPartySerializer.new(party), status: :created
+  end
+end

--- a/app/controllers/api/v1/movies_controller.rb
+++ b/app/controllers/api/v1/movies_controller.rb
@@ -9,4 +9,9 @@ class Api::V1::MoviesController < ApplicationController
 
     render json: MovieSerializer.new(movies)
   end
+
+  def show
+    movie = MovieDetails.build_movie_details(params[:id])
+    render json: MovieDetailsSerializer.new(movie)
+  end
 end 

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::SessionsController < ApplicationController
     if user && user.authenticate(params[:password])
       render json: UserSerializer.new(user)
     else
-      render json: ErrorSerializer.format_error(ErrorMessage.new("Invalid login credentials", 401)), status: :unauthorized
+      render json: ErrorSerializer.format_error("Invalid login credentials", 401), status: :unauthorized
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,6 +12,11 @@ class Api::V1::UsersController < ApplicationController
     render json: UserSerializer.format_user_list(User.all)
   end
 
+  def show
+    user = User.find(params[:id]) #Invalid ID is handled in rescue_from app controller
+    render json: UserProfileSerializer.new(user)
+  end
+
   private
 
   def user_params

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::UsersController < ApplicationController
     if user.save
       render json: UserSerializer.new(user), status: :created
     else
-      render json: ErrorSerializer.format_error(ErrorMessage.new(user.errors.full_messages.to_sentence, 400)), status: :bad_request
+      render json: ErrorSerializer.format_error(user.errors.full_messages.to_sentence, 400), status: :bad_request
     end
   end
 

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::ViewingPartiesController < ApplicationController
     if party.persisted?
       render json: ViewingPartySerializer.new(party), status: :created
     else
-      render json: ErrorSerializer.format_error(party.errors.full_messages.to_sentence, 422), status: :unprocessable_entity
+      render json: ErrorSerializer.format_errors_array(party.errors.full_messages, 422), status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/v1/viewing_parties_controller.rb
+++ b/app/controllers/api/v1/viewing_parties_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::ViewingPartiesController < ApplicationController
+  def create
+    party = ViewingParty.create_with_invitees(viewing_party_params.to_h)
+
+    if party.persisted?
+      render json: ViewingPartySerializer.new(party), status: :created
+    else
+      render json: ErrorSerializer.format_error(party.errors.full_messages.to_sentence, 422), status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def viewing_party_params
+    params.require(:viewing_party).permit(:name, :start_time, :end_time, :movie_id, :movie_title, invitees: [])
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,11 +5,7 @@ class ApplicationController < ActionController::API
   private
 
   def render_not_found(error)
-    if request.path.start_with?("/api/v1/movies")
-      render json: ErrorSerializer.format_errors_array(error.message, 404), status: :not_found
-    else
-      render json: ErrorSerializer.format_error(error.message, 404), status: :not_found
-    end
+    render json: ErrorSerializer.format_errors_array(error.message, 404), status: :not_found
   end
   
   def render_unprocessable(error)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::API
   private
 
   def render_not_found(error)
-    render json: ErrorSerializer.format_error(error.message, 400), status: :bad_request
+    render json: ErrorSerializer.format_error(error.message, 404), status: :not_found
   end
   
   def render_unprocessable(error)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable
+
+  private
+
+  def render_not_found(error)
+    render json: ErrorSerializer.format_error(error.message, 400), status: :bad_request
+  end
+  
+  def render_unprocessable(error)
+    render json: ErrorSerializer.format_error(error.message, 422), status: :unprocessable_entity
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,11 @@ class ApplicationController < ActionController::API
   private
 
   def render_not_found(error)
-    render json: ErrorSerializer.format_error(error.message, 404), status: :not_found
+    if request.path.start_with?("/api/v1/movies")
+      render json: ErrorSerializer.format_errors_array(error.message, 404), status: :not_found
+    else
+      render json: ErrorSerializer.format_error(error.message, 404), status: :not_found
+    end
   end
   
   def render_unprocessable(error)

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,4 +1,18 @@
 class Invitation < ApplicationRecord 
   belongs_to :user
   belongs_to :viewing_party
-end
+
+  def self.add_user_to_party(viewing_party_id, user_id)
+    viewing_party = ViewingParty.find(viewing_party_id)
+    user = User.find_by(id: user_id)
+    raise ActiveRecord::RecordNotFound, "Invalid user" unless user 
+
+    create!(
+      user: user,
+      viewing_party: viewing_party,
+      host: false
+    )
+
+    viewing_party
+  end
+end 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,0 +1,4 @@
+class Invitation < ApplicationRecord 
+  belongs_to :user
+  belongs_to :viewing_party
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,16 @@ class User < ApplicationRecord
   has_secure_password
   has_secure_token :api_key
 
+  def hosted_parties #filters just the invitations where user is host
+    invitations.where(host: true).map do |invitation|  
+      invitation.viewing_party #get the viewing party for each of those invitations 
+    end
+
+  end
+
+  def invited_parties #filters the invitations where user isn't the host 
+    invitations.where(host: false).map do |invitation|  
+      invitation.viewing_party #get the viewng party for each of those invitations 
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,7 @@
 class User < ApplicationRecord
+  has_many :invitations
+  has_many :viewing_parties, through: :invitations 
+
   validates :name, presence: true
   validates :username, presence: true, uniqueness: true
   validates :password, presence: { require: true }

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -1,0 +1,29 @@
+class ViewingParty < ApplicationRecord 
+  has_many :invitations
+  has_many :users, through: :invitations 
+
+  validates :name, presence: true
+  validates :movie_title, presence: true
+  validates :movie_id, presence: true 
+
+  def self.create_with_invitees(params)
+    invitees = params.delete(:invitees) #delete AND EXTRACT
+    party = ViewingParty.new(params) #initialize viewing party with params data (ruby object)
+
+    return party unless party.save #try to save party, if save fails, return early
+
+    invitees.each_with_index do |user_id, index| # Loop through User IDs
+      user = User.find_by(id: user_id)
+      raise ActiveRecord::RecordNotFound, "User ID #{user_id} not found" unless user
+
+      Invitation.create!(
+        user: user,
+        viewing_party: party,
+        host: index == 0 #know which one is first because of index block variable 
+      )
+    end #invitation belongs to party, Rails is just grabbing the foreign key party.id
+
+    party
+  end
+  
+end

--- a/app/models/viewing_party.rb
+++ b/app/models/viewing_party.rb
@@ -37,9 +37,6 @@ class ViewingParty < ApplicationRecord
     end
   end
 
-  validate :end_time_after_start_time
-  validate :duration_meets_runtime
-
   def duration_meets_runtime
     return if movie_id.blank? || start_time.blank? || end_time.blank?
 

--- a/app/poros/movie.rb
+++ b/app/poros/movie.rb
@@ -1,9 +1,10 @@
 class Movie
-  attr_reader :id, :title, :vote_average
+  attr_reader :id, :title, :vote_average, :runtime
 
   def initialize(data)
     @id = data[:id]
     @title = data[:title]
     @vote_average = data[:vote_average]
+    @runtime = data[:runtime]
   end
 end

--- a/app/poros/movie_details.rb
+++ b/app/poros/movie_details.rb
@@ -1,0 +1,56 @@
+class MovieDetails 
+  attr_reader :id, :title, :release_year, :vote_average, :runtime,
+              :genres, :summary, :cast, :total_reviews, :reviews
+
+  def initialize(details, credits, reviews)
+    @id = details[:id]
+    @title = details[:title]
+    @release_year = details[:release_date][0..3] #extract just the year
+    @vote_average = details[:vote_average]
+    @runtime = format_runtime(details[:runtime])
+    @genres = details[:genres].map { |genre| genre[:name] }
+    @summary = details[:overview]
+    @cast = format_cast(credits[:cast]) 
+    @total_reviews = reviews[:results].count
+    @reviews = format_reviews(reviews[:results])
+  end
+
+  def self.build_movie_details(movie_id)
+    details = MovieService.get_movie_details(movie_id)
+    credits = MovieService.get_movie_credits(movie_id)
+    reviews = MovieService.get_movie_reviews(movie_id)
+
+    if details.blank? || details[:id].nil? #Still shaky on this line of code
+      raise ActiveRecord::RecordNotFound, "Movie not found"
+    end
+  
+    MovieDetails.new(details, credits, reviews)
+  end
+
+  private
+
+  def format_runtime(minutes)
+    return "N/A" unless minutes
+    hours = minutes / 60
+    mins = minutes % 60
+    "#{hours} hours, #{mins} minutes"
+  end
+
+  def format_cast(cast_array)
+    cast_array.first(10).map do |member|
+      {
+        character: member[:character],
+        actor: member[:name]
+      }
+    end
+  end
+  
+  def format_reviews(review_array)
+    review_array.first(5).map do |review|
+      {
+        author: review[:author],
+        review: review[:content]
+      }
+    end
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -5,4 +5,13 @@ class ErrorSerializer
       status: status_code
     }
   end
+
+  def self.format_errors_array(messages, status_code) #creates an array if there are multiple errors 
+    {
+      errors: Array(messages).map do |msg|
+        { detail: msg }
+      end,
+      status: status_code
+    }
+  end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,8 +1,8 @@
 class ErrorSerializer
-  def self.format_error(error_message)
+  def self.format_error(message, status_code)
     {
-      message: error_message.message,
-      status: error_message.status_code
+      message: message,
+      status: status_code
     }
   end
 end

--- a/app/serializers/movie_details_serializer.rb
+++ b/app/serializers/movie_details_serializer.rb
@@ -1,0 +1,7 @@
+class MovieDetailsSerializer
+  include JSONAPI::Serializer
+  set_type :movie
+
+  attributes :title, :release_year, :vote_average, :runtime,
+  :genres, :summary, :cast, :total_reviews, :reviews
+end

--- a/app/serializers/user_profile_serializer.rb
+++ b/app/serializers/user_profile_serializer.rb
@@ -1,0 +1,34 @@
+class UserProfileSerializer
+  include JSONAPI::Serializer
+  set_type :user
+  attributes :name, :username
+
+  attribute :viewing_parties_hosted do |user|
+    user.hosted_parties.map do |party|
+      {
+        id: party.id,
+        name: party.name,
+        start_time: party.start_time,
+        end_time: party.end_time,
+        movie_id: party.movie_id,
+        movie_title: party.movie_title,
+        host_id: user.id
+      }
+    end
+  end
+
+  attribute :viewing_parties_invited do |user|
+    user.invited_parties.map do |party|
+      {
+        name: party.name,
+        start_time: party.start_time,
+        end_time: party.end_time,
+        movie_id: party.movie_id,
+        movie_title: party.movie_title,
+        host_id: party.invitations.find_by(host: true)&.user_id
+      }
+    end
+  end
+end
+
+  

--- a/app/serializers/viewing_party_serializer.rb
+++ b/app/serializers/viewing_party_serializer.rb
@@ -1,0 +1,7 @@
+class ViewingPartySerializer
+  include JSONAPI::Serializer
+
+  attributes :name, :start_time, :end_time, :movie_id, :movie_title 
+
+  has_many :users
+end

--- a/app/services/movie_service.rb
+++ b/app/services/movie_service.rb
@@ -31,4 +31,11 @@ class MovieService
       Movie.new(movie_data)
     end
   end
+
+  def self.get_movie_runtime(movie_id)
+    response = conn.get("movie/#{movie_id}")
+    json = JSON.parse(response.body, symbolize_names: true)
+
+    json[:runtime]
+  end
 end

--- a/app/services/movie_service.rb
+++ b/app/services/movie_service.rb
@@ -38,4 +38,19 @@ class MovieService
 
     json[:runtime]
   end
+
+  def self.get_movie_details(movie_id) #SRP, one of three helper methods
+    response = conn.get("movie/#{movie_id}")
+    json = JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.get_movie_credits(movie_id)
+    response = conn.get("movie/#{movie_id}/credits")
+    json = JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def self.get_movie_reviews(movie_id)
+    response = conn.get("movie/#{movie_id}/reviews")
+    json = JSON.parse(response.body, symbolize_names: true)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
       resources :users, only: [:create, :index]
       resources :sessions, only: :create
       resources :movies, only: :index
-      resources :viewing_parties, only: :create
+      resources :viewing_parties, only: :create do
+        resources :invitations, only: :create
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api do
     namespace :v1 do
-      resources :users, only: [:create, :index]
+      resources :users, only: [:create, :index, :show]
       resources :sessions, only: :create
       resources :movies, only: [:index, :show]
       resources :viewing_parties, only: :create do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       resources :users, only: [:create, :index]
       resources :sessions, only: :create
       resources :movies, only: :index
+      resources :viewing_parties, only: :create
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :users, only: [:create, :index]
       resources :sessions, only: :create
-      resources :movies, only: :index
+      resources :movies, only: [:index, :show]
       resources :viewing_parties, only: :create do
         resources :invitations, only: :create
       end

--- a/db/migrate/20250328151406_create_viewing_parties.rb
+++ b/db/migrate/20250328151406_create_viewing_parties.rb
@@ -1,0 +1,13 @@
+class CreateViewingParties < ActiveRecord::Migration[7.1]
+  def change
+    create_table :viewing_parties do |t|
+      t.string :name
+      t.datetime :start_time
+      t.datetime :end_time
+      t.integer :movie_id
+      t.string :movie_title
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250328151435_create_invitations.rb
+++ b/db/migrate/20250328151435_create_invitations.rb
@@ -1,0 +1,11 @@
+class CreateInvitations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :invitations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :viewing_party, null: false, foreign_key: true
+      t.boolean :host
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_23_211921) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_28_151435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "invitations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "viewing_party_id", null: false
+    t.boolean "host"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_invitations_on_user_id"
+    t.index ["viewing_party_id"], name: "index_invitations_on_viewing_party_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -24,4 +34,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_23_211921) do
     t.index ["api_key"], name: "index_users_on_api_key", unique: true
   end
 
+  create_table "viewing_parties", force: :cascade do |t|
+    t.string "name"
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.integer "movie_id"
+    t.string "movie_title"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "invitations", "users"
+  add_foreign_key "invitations", "viewing_parties"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    username { Faker::Internet.unique.username(specifier: 5..12) }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/factories/viewing_parties.rb
+++ b/spec/factories/viewing_parties.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :viewing_party do
+    name { "FactoryBot Movie Night" }
+    start_time { Time.now + 1.day }
+    end_time { Time.now + 1.day + 3.hours }
+    movie_id { 278 }
+    movie_title { "The Shawshank Redemption" }
+  end
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Invitation, type: :model do
+  describe ".add_user_to_party" do
+    let(:user) { create(:user) }
+    let(:party) do
+      build(:viewing_party, movie_id: 278).tap do |vp|
+        vp.save(validate: false)
+      end
+    end
+
+    before do
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278")
+        .with(query: hash_including({}))
+        .to_return(
+          status: 200,
+          body: {
+            id: 278,
+            title: "The Shawshank Redemption",
+            runtime: 120
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
+
+    it "creates an invitation when both user and party are valid" do
+      result = Invitation.add_user_to_party(party.id, user.id)
+      expect(result).to eq(party)
+      expect(Invitation.last.user).to eq(user)
+      expect(Invitation.last.viewing_party).to eq(party)
+    end
+
+    it "raises an error if the user is invalid" do
+      expect {
+        Invitation.add_user_to_party(party.id, 9999)
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,4 +9,42 @@ RSpec.describe User, type: :model do
     it { should have_secure_password }
     it { should have_secure_token(:api_key) }
   end
+
+  describe '#hosted_parties and #invited_parties' do
+    before do
+      stub_request(:get, "https://api.themoviedb.org/3/movie/603")
+        .with(query: hash_including({}))
+        .to_return(
+          status: 200,
+          body: {
+            id: 603,
+            title: "The Matrix",
+            runtime: 136
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
+
+    it 'returns only hosted parties for the user' do
+      user = create(:user)
+      party1 = ViewingParty.create!(name: "Matrix Night", movie_id: 603, movie_title: "The Matrix", start_time: 1.day.from_now, end_time: 1.day.from_now + 3.hours)
+      party2 = ViewingParty.create!(name: "Matrix Night 2", movie_id: 603, movie_title: "The Matrix", start_time: 2.days.from_now, end_time: 2.days.from_now + 3.hours)
+
+      Invitation.create!(user: user, viewing_party: party1, host: true)
+      Invitation.create!(user: user, viewing_party: party2, host: false)
+
+      expect(user.hosted_parties).to contain_exactly(party1)
+    end
+
+    it 'returns only invited (non-host) parties for the user' do
+      user = create(:user)
+      party1 = ViewingParty.create!(name: "Matrix Night", movie_id: 603, movie_title: "The Matrix", start_time: 1.day.from_now, end_time: 1.day.from_now + 3.hours)
+      party2 = ViewingParty.create!(name: "Matrix Night 2", movie_id: 603, movie_title: "The Matrix", start_time: 2.days.from_now, end_time: 2.days.from_now + 3.hours)
+
+      Invitation.create!(user: user, viewing_party: party1, host: true)
+      Invitation.create!(user: user, viewing_party: party2, host: false)
+
+      expect(user.invited_parties).to contain_exactly(party2)
+    end
+  end
 end

--- a/spec/models/viewing_party_spec.rb
+++ b/spec/models/viewing_party_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ViewingParty, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:movie_title) }
+    it { should validate_presence_of(:movie_id) }
+  end
+
+  describe "relationships" do
+    it { should have_many(:invitations) }
+    it { should have_many(:users).through(:invitations) }
+  end
+
+  describe "custom validations" do
+    before do
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278")
+        .with(query: hash_including({}))
+        .to_return(
+          status: 200,
+          body: {
+            id: 278,
+            title: "The Shawshank Redemption",
+            runtime: 142
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
+
+    it "is invalid if end_time is before start_time" do
+      party = build(:viewing_party, start_time: Time.now + 2.hours, end_time: Time.now + 1.hour)
+      party.valid?
+
+      expect(party.errors[:end_time]).to include("must be after start time")
+    end
+
+    it "is invalid if duration is shorter than movie runtime" do
+      party = build(:viewing_party, start_time: Time.now, end_time: Time.now + 1.hour)
+      party.valid?
+
+      expect(party.errors[:base]).to include("Party duration must be at least the length of the movie")
+    end
+
+    it "is valid with a proper duration and time sequence" do
+      party = build(:viewing_party, start_time: Time.now, end_time: Time.now + 3.hours)
+
+      expect(party).to be_valid
+    end
+  end
+end

--- a/spec/poros/movie_details_spec.rb
+++ b/spec/poros/movie_details_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe MovieDetails do
+  describe '.build_movie_details' do
+    before do
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: {
+          id: 278,
+          title: "The Shawshank Redemption",
+          release_date: "1994-09-23",
+          vote_average: 8.7,
+          runtime: 142,
+          genres: [
+            { id: 18, name: "Drama" },
+            { id: 80, name: "Crime" }
+          ],
+          overview: "Imprisoned in the 1940s for the double murder..."
+        }.to_json)
+
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278/credits")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: {
+          cast: [
+            { character: "Andy Dufresne", name: "Tim Robbins" },
+            { character: "Red", name: "Morgan Freeman" }
+          ]
+        }.to_json)
+
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278/reviews")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: {
+          results: [
+            { author: "elshaarawy", content: "Great movie!" },
+            { author: "John Chard", content: "Some birds aren't meant to be caged." }
+          ]
+        }.to_json)
+    end
+
+    it 'returns a MovieDetails object with formatted data' do
+      movie = MovieDetails.build_movie_details(278)
+
+      expect(movie).to be_a(MovieDetails)
+      expect(movie.id).to eq(278)
+      expect(movie.title).to eq("The Shawshank Redemption")
+      expect(movie.release_year).to eq("1994")
+      expect(movie.vote_average).to eq(8.7)
+      expect(movie.runtime).to eq("2 hours, 22 minutes")
+      expect(movie.genres).to eq(["Drama", "Crime"])
+      expect(movie.summary).to be_a(String)
+      expect(movie.cast.length).to be <= 10
+      expect(movie.total_reviews).to eq(2)
+      expect(movie.reviews.length).to eq(2)
+      expect(movie.reviews.first).to have_key(:author)
+      expect(movie.reviews.first).to have_key(:review)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,8 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
+  config.include FactoryBot::Syntax::Methods
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/requests/api/v1/invitations_request_spec.rb
+++ b/spec/requests/api/v1/invitations_request_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe "Invitations API", type: :request do
+  describe "POST /api/v1/viewing_parties/:id/invitations" do
+    it "successfully invites a new user to an existing viewing party" do 
+
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278")
+      .with(query: hash_including({}))
+      .to_return(
+        status: 200,
+        body: {
+          id: 278,
+          title: "The Shawshank Redemption",
+          runtime: 142
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+      party = create(:viewing_party)
+      existing_users = create_list(:user, 2) 
+      party.users << existing_users #pre-load party with 2 users
+
+      new_user = create(:user) #new invitee
+
+      post "/api/v1/viewing_parties/#{party.id}/invitations",
+        params: {invitees_user_id: new_user.id}.to_json, #add new_user as invitee in request body
+        headers: { "CONTENT_TYPE" => "application/json" }
+      
+      expect(response).to have_http_status(:created)
+
+      json = JSON.parse(response.body, symbolize_names: true)
+      invited_ids = json[:data][:relationships][:users][:data].map { |user| user[:id].to_i } #convert json string to integer
+
+      expect(Invitation.count).to eq(3)
+      expect(invited_ids).to include(new_user.id)
+    end
+  end
+
+  describe "POST Sad Paths" do 
+    it "raises an error with an invalid viewing_party_id" do 
+      invalid_party_id = 9999
+      user = create(:user)
+  
+      post "/api/v1/viewing_parties/#{invalid_party_id}/invitations",
+        params: { invitees_user_id: user.id }.to_json,
+        headers: { "CONTENT_TYPE" => "application/json" }
+  
+      json = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(response).to have_http_status(:not_found)
+      expect(json[:status]).to eq(404)
+      expect(json[:message]).to match(/Couldn't find ViewingParty/)
+      expect(Invitation.count).to eq(0)
+    end
+
+    it "raises an error with an invalid user_id" do
+      party = build(:viewing_party)
+      party.save(validate: false)
+    
+      invalid_user_id = 9999 #not in the database
+    
+      post "/api/v1/viewing_parties/#{party.id}/invitations",
+        params: { invitees_user_id: invalid_user_id }.to_json,
+        headers: { "CONTENT_TYPE" => "application/json" }
+    
+      json = JSON.parse(response.body, symbolize_names: true)
+    
+      expect(response).to have_http_status(:not_found)
+      expect(json[:status]).to eq(404)
+      expect(json[:message]).to match(/Invalid user/i)
+      expect(Invitation.count).to eq(0)
+    end
+  end
+end 

--- a/spec/requests/api/v1/invitations_request_spec.rb
+++ b/spec/requests/api/v1/invitations_request_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Invitations API", type: :request do
       
       expect(response).to have_http_status(:not_found)
       expect(json[:status]).to eq(404)
-      expect(json[:message]).to match(/Couldn't find ViewingParty/)
+      expect(json[:errors].first[:detail]).to match(/Couldn't find ViewingParty/)
       expect(Invitation.count).to eq(0)
     end
 
@@ -67,7 +67,7 @@ RSpec.describe "Invitations API", type: :request do
     
       expect(response).to have_http_status(:not_found)
       expect(json[:status]).to eq(404)
-      expect(json[:message]).to match(/Invalid user/i)
+      expect(json[:errors].first[:detail]).to match(/Invalid user/i)
       expect(Invitation.count).to eq(0)
     end
   end

--- a/spec/requests/api/v1/movies_request_spec.rb
+++ b/spec/requests/api/v1/movies_request_spec.rb
@@ -71,4 +71,85 @@ RSpec.describe "Movies endpoints", type: :request do
       end
     end
   end
+
+  describe "GET /api/v1/movies/:id" do
+    it "returns detailed info for a specific movie" do
+      movie_id = 278
+  
+      stub_request(:get, "https://api.themoviedb.org/3/movie/#{movie_id}")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: {
+          id: 278,
+          title: "The Shawshank Redemption",
+          release_date: "1994-09-23",
+          vote_average: 8.7,
+          runtime: 142,
+          genres: [{ name: "Drama" }, { name: "Crime" }],
+          overview: "Summary of the movie"
+        }.to_json, headers: { "Content-Type" => "application/json" })
+  
+      stub_request(:get, "https://api.themoviedb.org/3/movie/#{movie_id}/credits")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: {
+          cast: [
+            { character: "Andy Dufresne", name: "Tim Robbins" },
+            { character: "Red", name: "Morgan Freeman" }
+          ]
+        }.to_json, headers: { "Content-Type" => "application/json" })
+  
+      stub_request(:get, "https://api.themoviedb.org/3/movie/#{movie_id}/reviews")
+        .with(query: hash_including({}))
+        .to_return(status: 200, body: {
+          results: [
+            { author: "elshaarawy", content: "A classic." },
+            { author: "john_doe", content: "Loved it!" }
+          ]
+        }.to_json, headers: { "Content-Type" => "application/json" })
+  
+      get "/api/v1/movies/#{movie_id}"
+  
+      expect(response).to be_successful
+  
+      json = JSON.parse(response.body, symbolize_names: true)
+  
+      expect(json[:data][:id]).to eq(movie_id.to_s)
+      expect(json[:data][:attributes][:title]).to eq("The Shawshank Redemption")
+      expect(json[:data][:attributes][:release_year]).to eq("1994")
+      expect(json[:data][:attributes][:runtime]).to eq("2 hours, 22 minutes")
+      expect(json[:data][:attributes][:genres]).to include("Drama", "Crime")
+      expect(json[:data][:attributes][:summary]).to be_a(String)
+      expect(json[:data][:attributes][:cast].first).to include(:character, :actor)
+      expect(json[:data][:attributes][:total_reviews]).to eq(2)
+      expect(json[:data][:attributes][:reviews].first).to include(:author, :review)
+    end
+
+    it "returns 404 if the movie is not found" do
+      invalid_id = 9999999
+  
+      stub_request(:get, "https://api.themoviedb.org/3/movie/#{invalid_id}")
+        .with(query: hash_including({}))
+        .to_return(status: 404, body: {
+          status_message: "The resource you requested could not be found."
+        }.to_json, headers: { "Content-Type" => "application/json" })
+
+      stub_request(:get, "https://api.themoviedb.org/3/movie/#{invalid_id}/credits")
+        .with(query: hash_including({}))
+        .to_return(status: 404, body: {
+          status_message: "The resource you requested could not be found."
+        }.to_json, headers: { "Content-Type" => "application/json" })
+      
+      stub_request(:get, "https://api.themoviedb.org/3/movie/#{invalid_id}/reviews")
+        .with(query: hash_including({}))
+        .to_return(status: 404, body: {
+          status_message: "The resource you requested could not be found."
+        }.to_json, headers: { "Content-Type" => "application/json" })
+  
+      get "/api/v1/movies/#{invalid_id}"
+  
+      expect(response).to have_http_status(:not_found)
+  
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json[:errors].first[:detail]).to match(/not found/i)
+    end
+  end
 end 

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe "ViewingParties API", type: :request do
+  describe "POST /api/v1/viewing_parties" do
+    it "creates a viewing party with valid invitees" do 
+
+      invitees = create_list(:user, 3)
+
+      valid_params = {
+        viewing_party: {
+          name: "Juliet's Bday Movie Bash!",
+          start_time: "2025-02-01 10:00:00",
+          end_time: "2025-02-01 14:30:00",
+          movie_id: 278,
+          movie_title: "The Shawshank Redemption",
+          invitees: invitees.map(&:id)
+        }
+      }
+
+      post "/api/v1/viewing_parties", params: valid_params.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+      
+      json = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to have_http_status(:created)
+      expect(ViewingParty.count).to eq(1)
+      expect(Invitation.count).to eq(3)
+
+      expect(json[:data]).to have_key(:id)
+      expect(json[:data][:type]).to eq("viewing_party")
+      expect(json[:data][:attributes][:name]).to eq("Juliet's Bday Movie Bash!")
+      expect(json[:data][:relationships][:users][:data].count).to eq(3)
+    end
+  end
+end

--- a/spec/requests/api/v1/viewing_parties_request_spec.rb
+++ b/spec/requests/api/v1/viewing_parties_request_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe "ViewingParties API", type: :request do
+  before do
+    stub_request(:get, "https://api.themoviedb.org/3/movie/278")
+      .with(query: hash_including({}))
+      .to_return(
+        status: 200,
+        body: {
+          id: 278,
+          title: "The Shawshank Redemption",
+          runtime: 142
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
   describe "POST /api/v1/viewing_parties" do
     it "creates a viewing party with valid invitees" do 
 
@@ -31,4 +45,124 @@ RSpec.describe "ViewingParties API", type: :request do
       expect(json[:data][:relationships][:users][:data].count).to eq(3)
     end
   end
+
+  describe "POST Sad Paths/Edge Cases" do 
+    it "returns an error when required attributes are missing" do
+      invitees = create_list(:user, 3)
+    
+      bad_params = {
+        viewing_party: {
+          #name is missing
+          start_time: "2025-02-01 10:00:00",
+          end_time: "2025-02-01 14:30:00",
+          movie_id: nil,
+          movie_title: "", #blank on purpose
+          invitees: invitees.map(&:id)
+        }
+      }
+
+      stub_request(:get, /api.themoviedb.org/).to_return( #regex matches any TMDB URL here
+        status: 200,
+        body: { runtime: 142 }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+    
+      post "/api/v1/viewing_parties", params: bad_params.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    
+      json = JSON.parse(response.body, symbolize_names: true)
+    
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json[:status]).to eq(422)
+      messages = json[:errors].map { |e| e[:detail] }
+      expect(messages).to include("Name can't be blank")
+    end
+
+    it "returns an error if runtime is less than party duration" do
+      invitees = create_list(:user, 3)
+    
+      bad_params = {
+        viewing_party: {
+          name: "Juliet's Bday Movie Bash!",
+          start_time: "2025-02-01 10:00:00",
+          end_time: "2025-02-01 11:00:00", #duration is only an hour
+          movie_id: 278,
+          movie_title: "The Shawshank Redemption",
+          invitees: invitees.map(&:id)
+        }
+      }
+    
+      post "/api/v1/viewing_parties", params: bad_params.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    
+      json = JSON.parse(response.body, symbolize_names: true)
+    
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json[:status]).to eq(422)
+
+      messages = json[:errors].map { |error| error[:detail] }
+      expect(messages).to include("Party duration must be at least the length of the movie")
+    end
+
+    it "returns an error if end time is before start time" do
+      invitees = create_list(:user, 3)
+    
+      bad_params = {
+        viewing_party: {
+          name: "Backwards Bash!",
+          start_time: "2025-02-01 14:30:00",   #starts later
+          end_time: "2025-02-01 10:00:00",     #ends earlier
+          movie_id: 278,
+          movie_title: "The Shawshank Redemption",
+          invitees: invitees.map(&:id)
+        }
+      }
+    
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278")
+        .with(query: hash_including({}))
+        .to_return(
+          status: 200,
+          body: {
+            id: 278,
+            title: "The Shawshank Redemption",
+            runtime: 142
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    
+      post "/api/v1/viewing_parties", params: bad_params.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    
+      json = JSON.parse(response.body, symbolize_names: true)
+    
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(json[:status]).to eq(422)
+
+      messages = json[:errors].map { |e| e[:detail] }
+      expect(messages).to include("End time must be after start time")
+    end
+
+    it "can create a viewing party with partially valid user id input" do
+      valid_users = create_list(:user, 2)
+      invalid_ids = [999, 1234] #these IDs don't exist
+      invitees = valid_users.map(&:id) + invalid_ids
+    
+      params = {
+        viewing_party: {
+          name: "Juliet's Bday Movie Bash!",
+          start_time: "2025-02-01 10:00:00",
+          end_time: "2025-02-01 14:30:00",
+          movie_id: 278,
+          movie_title: "The Shawshank Redemption", 
+          invitees: invitees
+        }
+      }
+    
+      post "/api/v1/viewing_parties", params: params.to_json, headers: { "CONTENT_TYPE" => "application/json" }
+    
+      json = JSON.parse(response.body, symbolize_names: true)
+    
+      expect(ViewingParty.count).to eq(1)
+      expect(Invitation.count).to eq(2)
+      expect(response).to have_http_status(:created)
+    end
+  end
 end
+

--- a/spec/services/movie_service_spec.rb
+++ b/spec/services/movie_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe MovieService do 
-  describe 'INDEX / .get_top_rated_movies' do 
+  describe '.get_top_rated_movies' do 
     it 'returns parsed movie data from TMDB API' do 
       stub_request(:get, "https://api.themoviedb.org/3/movie/top_rated")
       .with(query: hash_including({ "page" => "1" }))
@@ -24,7 +24,7 @@ RSpec.describe MovieService do
     end
   end
 
-  describe 'INDEX / .search_movies' do 
+  describe '.search_movies' do 
     it 'returns parsed movie data from TMDB API based on search params' do 
       stub_request(:get, "https://api.themoviedb.org/3/search/movie")
       .with(query: hash_including({ "page" => "1" }))
@@ -46,6 +46,26 @@ RSpec.describe MovieService do
       expect(response.length).to eq(3)
       expect(response.first.title).to eq("The Lord of the Rings: The Fellowship of the Ring")
       expect(response.first.vote_average).to eq(8.413)
+    end
+  end
+
+  describe '.get_movie_runtime' do
+    it 'returns the runtime of a specific movie by ID' do
+      stub_request(:get, "https://api.themoviedb.org/3/movie/278")
+        .with(query: hash_including({}))
+        .to_return(
+          status: 200,
+          body: {
+            id: 278,
+            title: "The Shawshank Redemption",
+            runtime: 142
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+  
+      runtime = MovieService.get_movie_runtime(278)
+  
+      expect(runtime).to eq(142)
     end
   end
 end


### PR DESCRIPTION
### Type of change

- [x] New feature  
- [ ] Bug Fix

---

### Check the correct boxes

- [x] This code broke nothing  
- [ ] This code broke some stuff  
- [ ] This code broke everything  

---

### Implements/Fixes:

- Implemented full flow of Viewing Party functionality:
  - **Endpoint 3:** Created Viewing Party with custom validation logic for start/end time and movie runtime.
  - **Endpoint 4:** Added ability to invite additional users to existing Viewing Parties (via nested `POST /invitations`).
  - **Endpoint 5:** Retrieved full movie details from TMDB using 3 endpoints and formatted with a PORO and custom serializer.
  - **Endpoint 6:** Retrieved full user profile including hosted and invited viewing parties, excluding sensitive data.
- All endpoints follow RESTful conventions and return JSON:API compliant responses.
- Added comprehensive model, request, and PORO tests using stubs and mock data.
- Refactored error serialization to ensure consistent error formatting across controllers.

---

### Testing Changes:

- [x] I have fully tested my code  
- [x] All tests are passing  
- [ ] Some tests are failing  
- [ ] All tests are failing

- [ ] No previous tests have been changed  
- [x] Some previous tests have been changed  
- [ ] All of the previous tests have been changed (Please describe what in the world happened that all of the previous tests needed changing.)

---

### Checklist:

- [x] I have reviewed my code  
- [x] The code will run locally  
- [x] My code has no unused/commented out code  
- [x] I have commented my code, particularly in hard-to-understand areas  

---

### (Optional) What questions do you have? Anything specific you want feedback on?

- Would love feedback on error handling patterns — balancing flexibility vs. consistency.
- Could the PORO and MovieService methods be simplified or better modularized?
- Any thoughts on my use of serializers, particularly the nested mapping in `UserProfileSerializer`?

---

![Mission Accomplished](https://img.buzzfeed.com/buzzfeed-static/static/2017-03/28/13/asset/buzzfeed-prod-fastlane-01/sub-buzz-1131-1490721085-11.jpg?downsize=600:*&output-format=auto&output-quality=auto)